### PR TITLE
Fix --version output to include a value

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
 GO_SRC=$(shell find . -name \*.go)
+MAIN_VERSION=1.0.0
 
 default: $(GO_SRC)
-	go build
+	go build -ldflags "-X main.version=$(MAIN_VERSION)"
 
 .PHONY: check
 check:


### PR DESCRIPTION
The current output of `octoci --version` does not have a version value.  Pick an arbitrary value and insert it into the go binary via ldflag option.